### PR TITLE
Detect Unindented Sequence of Maps

### DIFF
--- a/src/yaml/YamlParser.js
+++ b/src/yaml/YamlParser.js
@@ -342,10 +342,15 @@ YamlParser.prototype =
 
 		var isItUnindentedCollection = this.isStringUnIndentedCollectionItem(this.currentLine);
 
+		var continuationIndent = -1;
+		if (isItUnindentedCollection === true) {
+			continuationIndent = 1 + /^\-((\s+)(.+?))?\s*$/.exec(this.currentLine)[2].length;
+		}
+
 		while ( this.moveToNextLine() )
 		{
 
-			if (isItUnindentedCollection && !this.isStringUnIndentedCollectionItem(this.currentLine)) {
+			if (isItUnindentedCollection && !this.isStringUnIndentedCollectionItem(this.currentLine) && this.getCurrentLineIndentation() != continuationIndent) {
 				this.moveToPreviousLine();
 				break;
 			}

--- a/test/libs/jasmine-1.2.0/YamlTests.js
+++ b/test/libs/jasmine-1.2.0/YamlTests.js
@@ -66,6 +66,16 @@ bar:\n\
 		output: { 'foo' : 'whatever', 'bar' : [ 'uno', 'dos' ] } 
 	},
 	{
+		title: "Unindented Sequence in a Mapping",
+		input:
+'\
+foo:\n\
+- uno: 1\n\
+  dos: 2\n\
+',
+		output: { 'foo' : [ {'uno': 1, 'dos': 2} ] }
+	},
+	{
 		title: "Nested Mappings",
 		input: 
 '\


### PR DESCRIPTION
I could not get Jasmine to fail the test and I do
not know the right names for YAML types, but I did
the best I could.

The demo failed on this YAML:

```
test:
- something: 1
  test: 2
```

This patch should fix that.
