### PR TITLE
Callback fix and context bind for resolving asynchronous load errors

### DIFF
--- a/bin/yaml.js
+++ b/bin/yaml.js
@@ -209,11 +209,16 @@ Yaml.prototype =
 			}
 			return ret;
 		}
-		
-		this.getFileContents(file, function(data)
+
+		this.getFileContents(file, function(err, data)
 		{
-			callback(new Yaml().parse(data));
-		});
+			if (err) return callback(err);
+
+			ret = this.parse(data);
+
+			callback(null, ret);
+
+		}.bind(this));
 	},
 
 	/**
@@ -301,12 +306,13 @@ Yaml.prototype =
 	        }
 	        else
 	        {
-	            fs.readFile(file, function(err, data)
+  						fs.readFile(file, function(err, data)
 	            {
-	                if (err)
-	                    callback(null);
-	                else
-	                    callback(data);
+	            		if (err) {
+	                    callback(err);
+	                } else {
+	                		callback(null, ''+data);
+	                }
 	            });
 	        }
 	    }


### PR DESCRIPTION
The callback for getGetFileContents was erroneously calling back into
the error argument (on success) in the load method. Also added a
context binding to getFileContents callback scope, so that a new Yaml()
class doesn't have to be re-instantiated for parsing, when using
asyncronous file reading.
