### PR TITLE
dumping empty string to ""

### DIFF
--- a/src/yaml/YamlInline.js
+++ b/src/yaml/YamlInline.js
@@ -74,7 +74,7 @@ YamlInline.prototype =
 		if ( yaml.requiresSingleQuoting(value) )
 			return yaml.escapeWithSingleQuotes(value);
 		if ( '' == value )
-			return "";
+			return '""';
 		if ( this.getTimestampRegex().test(value) )
 			return "'"+value+"'";
 		if ( this.inArray(value.toLowerCase(), ['null','~','true','false']) )


### PR DESCRIPTION
if we have a JSON, o = {"test": ["", null], "n": null, "": ""} 
Before this change YAML.parse(YAML.stringify(o)) is not o

I'm not 100% sure whether this change goes along with spec. 
