### PR TITLE
Changed hash inheritance to clone source object 

### DIFF
--- a/bin/yaml.js
+++ b/bin/yaml.js
@@ -1175,7 +1175,9 @@ YamlParser.prototype =
 				{
 					if ( isInPlace )
 					{
-						data = this.refs[isInPlace];
+					    // when merging objects, need to clone the source object to prevent overrides in
+					    // the target object from affecting the source object.
+						data = JSON.parse(JSON.stringify(this.refs[isInPlace]));
 					}
 					else
 					{

--- a/src/yaml/YamlParser.js
+++ b/src/yaml/YamlParser.js
@@ -224,7 +224,9 @@ YamlParser.prototype =
 				{
 					if ( isInPlace )
 					{
-						data = this.refs[isInPlace];
+					    // when merging objects, need to clone the source object to prevent overrides in
+					    // the target object from affecting the source object.
+						data = JSON.parse(JSON.stringify(this.refs[isInPlace]));
 					}
 					else
 					{

--- a/test/libs/jasmine-1.2.0/YamlTests.js
+++ b/test/libs/jasmine-1.2.0/YamlTests.js
@@ -694,6 +694,21 @@ bar: |\n\
 		   'bar' : "fooness\n" 
 		} 
 		
+	{
+		title: "Merging Hashes with Inheritance",
+		input:
+"\
+source: &source\n\
+    foo: bar\n\
+target:\n\
+    <<: *source\n\
+    foo: qux\n\
+",
+		output: {
+		    'source' : { 'foo': 'bar' },
+		    'target' : { 'foo': 'qux' }
+		}
+
 	},
 	
 ];


### PR DESCRIPTION
... Instead of re-using it, so that overrides in target don't affect values in source.

Previously, the following YAML string:

``` yaml
source: &source
    foo: bar
target:
    <<: *source
    foo: qux
```

would parse to

```
{
  "source": { "foo": "qux" },
  "target": { "foo": "qux" }
}
```

instead of expected

```
{
  "source": { "foo": "bar" },
  "target": { "foo": "qux" }
}
```
