### PR TITLE
Bump glob version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "./lib/Yaml.js",
   "dependencies": {
     "argparse": "^0.1.15",
-    "glob": "^3.1.21",
+    "glob": "^4.0.0",
     "coffeeify": "^0.7.0",
     "benchmark": "^1.0.0",
     "jasmine-node": "^1.14.5"


### PR DESCRIPTION
`glob` has been update to bump to `4.0.0` for a while
https://github.com/isaacs/node-glob/commit/865070485630b8f13c632bb6352a2a425011cd2f 

Should be safe to upgrade
