### PR TITLE
add missing license

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "yaml2json": "./bin/yaml2json",
     "json2yaml": "./bin/json2yaml"
   },
+  "license": "MIT",
   "devDependencies": {},
   "repository": {
     "type": "git",


### PR DESCRIPTION
cuz recently npm updated its guidelines on license metadata in package.json files and your module is also listed in www.npm1k.org

ref https://github.com/npm/npm/releases/tag/v2.10.0
