### PR TITLE
Fixed bug where empty arrays where being missed off the dump

### DIFF
--- a/lib/Dumper.js
+++ b/lib/Dumper.js
@@ -38,8 +38,12 @@ Dumper = (function() {
       } else {
         for (key in input) {
           value = input[key];
-          willBeInlined = inline - 1 <= 0 || typeof value !== 'object' || Utils.isEmpty(value);
-          output += prefix + Inline.dump(key, exceptionOnInvalidType, objectEncoder) + ':' + (willBeInlined ? ' ' : "\n") + this.dump(value, inline - 1, (willBeInlined ? 0 : indent + this.indentation), exceptionOnInvalidType, objectEncoder) + (willBeInlined ? "\n" : '');
+          if(value instanceof Array && value.length === 0) {
+            output += prefix + Inline.dump(key, exceptionOnInvalidType, objectEncoder) + ": []\n";
+          } else {
+            willBeInlined = inline - 1 <= 0 || typeof value !== 'object' || Utils.isEmpty(value);
+            output += prefix + Inline.dump(key, exceptionOnInvalidType, objectEncoder) + ':' + (willBeInlined ? ' ' : "\n") + this.dump(value, inline - 1, (willBeInlined ? 0 : indent + this.indentation), exceptionOnInvalidType, objectEncoder) + (willBeInlined ? "\n" : '');
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "yamljs",
-  "version": "0.2.3",
-  "description": "Standalone JavaScript YAML 1.2 Parser & Encoder. Works under node.js and all major browsers. Also brings command line YAML/JSON conversion tools.",
+  "name": "ts-yamljs",
+  "version": "1.0.0",
+  "description": "Standalone JavaScript YAML 1.2 Parser & Encoder. Works under node.js and all major browsers. Also brings command line YAML/JSON conversion tools. Based on Jeremy Faivre's yamljs but with bugfixes",
   "keywords": [
     "yaml",
     "json",
     "yaml2json",
     "json2yaml"
   ],
-  "author": "Jeremy Faivre <contact@jeremyfa.com>",
+  "author": "Warrick Hill <warrick.hill@toolstation.com>",
   "main": "./lib/Yaml.js",
   "dependencies": {
     "argparse": "^0.1.15",
@@ -25,6 +25,6 @@
   "devDependencies": {},
   "repository": {
     "type": "git",
-    "url": "git://github.com/jeremyfa/yaml.js.git"
+    "url": "https://github.com/warrickhill/yaml.js"
   }
 }


### PR DESCRIPTION
I am using grunt to merge yaml configs and outputing the results back to a yaml file so a php script could use it in production. however the output was missing empty arrays [] so the php script was falling over. this show fix that problem
