### PR TITLE
Ignore empty lines for smallest indent

### DIFF
--- a/src/Parser.coffee
+++ b/src/Parser.coffee
@@ -608,6 +608,7 @@ class Parser
         lines = value.split("\n")
         smallestIndent = -1
         for line in lines
+            continue if Utils.trim(line, ' ').length == 0
             indent = line.length - Utils.ltrim(line).length
             if smallestIndent is -1 or indent < smallestIndent
                 smallestIndent = indent

--- a/test/spec/YamlSpec.coffee
+++ b/test/spec/YamlSpec.coffee
@@ -142,7 +142,10 @@ describe 'Parsed YAML Collections', ->
                     job: 'Accountant'
                     age: 38
 
+    it 'can ignore trailing empty lines for smallest indent', ->
 
+        expect YAML.parse """ trailing: empty lines\n"""
+        .toEqual trailing: 'empty lines'
 
 describe 'Parsed YAML Inline Collections', ->
 


### PR DESCRIPTION
Hi @jeremyfa 

I had a problem to parse `str:  "with leading spaces in the line"\n` with your library. Although I just didn't realize I mistakenly put the leading whitespace, I think we can handle this case because the other library such as Ruby's yaml parser can.
