### PR TITLE
replaceAll always replace str with ''

### DIFF
--- a/src/Pattern.coffee
+++ b/src/Pattern.coffee
@@ -134,7 +134,7 @@ class Pattern
         count = 0
         while @regex.test(str) and (limit is 0 or count < limit)
             @regex.lastIndex = 0
-            str = str.replace @regex, ''
+            str = str.replace @regex, replacement
             count++
         
         return [str, count]


### PR DESCRIPTION
Should replace matching string with parameter "replacement", not ''.