### PR TITLE
Remove newlines before objects in arrays

### DIFF
--- a/src/Dumper.coffee
+++ b/src/Dumper.coffee
@@ -34,8 +34,7 @@ class Dumper
 
                     output +=
                         prefix +
-                        '-' +
-                        (if willBeInlined then ' ' else "\n") +
+                        '- ' +
                         @dump(value, inline - 1, (if willBeInlined then 0 else indent + @indentation), exceptionOnInvalidType, objectEncoder) +
                         (if willBeInlined then "\n" else '')
 


### PR DESCRIPTION
Currently, yaml.js adds an unnecessary newline when converting an array of objects to YAML output. This is demonstrated below:

```YAML
spec:
  tls:
    -
      hosts:
        - example1.com
        - example2.com
      secretName: example-tls-secret
```

Instead, the output should probably look like:

```YAML
spec:
  tls:
    - hosts:
        - example1.com
        - example2.com
      secretName: example-tls-secret
```

The reasoning for this is because the newline that's being added does not follow the current industry standard code style for YAML.

For reference, here are some YAML snippets that were written by the official YAML website, Google, Docker, and Travis CI (respectively):

<img width="880" alt="screen shot 2017-10-23 at 11 40 27 am" src="https://user-images.githubusercontent.com/3850064/31901777-153a6698-b7e8-11e7-899e-dae05d9ac766.png">

<img width="272" alt="screen shot 2017-10-23 at 11 42 29 am" src="https://user-images.githubusercontent.com/3850064/31901781-1b5bd55c-b7e8-11e7-9748-c419e3d13651.png">

<img width="560" alt="screen shot 2017-10-23 at 11 54 20 am" src="https://user-images.githubusercontent.com/3850064/31902002-f3678db0-b7e8-11e7-96a5-c85038b0cd19.png">

<img width="869" alt="screen shot 2017-10-23 at 11 40 14 am" src="https://user-images.githubusercontent.com/3850064/31901751-037d84e4-b7e8-11e7-9037-f1b1fbb1aff8.png">
