### PR TITLE
Fixes #121

### DIFF
--- a/src/Escaper.coffee
+++ b/src/Escaper.coffee
@@ -31,7 +31,7 @@ class Escaper
 
     # Other precompiled patterns
     @PATTERN_MAPPING_ESCAPEES:      new Pattern @LIST_ESCAPEES.join('|').split('\\').join('\\\\')
-    @PATTERN_SINGLE_QUOTING:        new Pattern '[\\s\'":{}[\\],&*#?]|^[-?|<>=!%@`]'
+    @PATTERN_SINGLE_QUOTING:        new Pattern '[\\s\'"{}[\\],&*#?]|^[-?|<>=!%@`]'
 
 
 


### PR DESCRIPTION
#121 escape pattern is wrong: unnecessarily adds single quotes to strings that contain ':'